### PR TITLE
[Demo][DNM] Add OpenLab CI configuration for ARM64 build

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,13 @@
+- project:
+    name: theopenlab/storm
+    check:
+      jobs:
+        - storm-build-arm64
+
+- job:
+    name: storm-build-arm64
+    parent: init-test
+    description: |
+      The storm build in openlab cluster.
+    run: .zuul/playbooks/storm-build/run.yaml
+    nodeset: ubuntu-xenial-arm64

--- a/.zuul/playbooks/storm-build/run.yaml
+++ b/.zuul/playbooks/storm-build/run.yaml
@@ -1,0 +1,27 @@
+- hosts: all
+  become: yes
+  tasks:
+    - name: Build storm
+      shell:
+        cmd: |
+          wget https://www.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
+          tar -xzf apache-maven-3.5.4-bin.tar.gz
+          export PATH=$PWD/apache-maven-3.5.4/bin:$PATH
+          
+          command curl -sSL https://rvm.io/mpapis.asc | sudo gpg --import -
+          command curl -sSL https://rvm.io/pkuczynski.asc | sudo gpg --import -
+          curl -L https://get.rvm.io | bash -s stable --autolibs=enabled && source ~/.profile
+          
+          source /etc/profile.d/rvm.sh
+          
+          wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.26.1/install.sh | bash && source ~/.bashrc
+          rvm use 2.4.2 --install
+          nvm install 8.9.3
+          
+          pip install mock
+          pip3 install mock
+          
+          mvn clean install -DskipTests
+        chdir: '{{ zuul.project.src_dir }}'
+        executable: /bin/bash
+      environment: '{{ global_env }}'

--- a/.zuul/playbooks/storm-build/run.yaml
+++ b/.zuul/playbooks/storm-build/run.yaml
@@ -4,6 +4,9 @@
     - name: Build storm
       shell:
         cmd: |
+          set -xe
+          # Let job down to test the non-voting job
+          exit 1
           wget https://www.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
           tar -xzf apache-maven-3.5.4-bin.tar.gz
           export PATH=$PWD/apache-maven-3.5.4/bin:$PATH

--- a/.zuul/playbooks/storm-build/run.yaml
+++ b/.zuul/playbooks/storm-build/run.yaml
@@ -11,12 +11,12 @@
           command curl -sSL https://rvm.io/mpapis.asc | sudo gpg --import -
           command curl -sSL https://rvm.io/pkuczynski.asc | sudo gpg --import -
           curl -L https://get.rvm.io | bash -s stable --autolibs=enabled && source ~/.profile
-          
           source /etc/profile.d/rvm.sh
-          
-          wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.26.1/install.sh | bash && source ~/.bashrc
           rvm use 2.4.2 --install
-          nvm install 8.9.3
+
+          curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+          apt-get update
+          apt-get install -y nodejs
           
           pip install mock
           pip3 install mock

--- a/.zuul/playbooks/storm-build/run.yaml
+++ b/.zuul/playbooks/storm-build/run.yaml
@@ -4,9 +4,6 @@
     - name: Build storm
       shell:
         cmd: |
-          set -xe
-          # Let job down to test the non-voting job
-          exit 1
           wget https://www.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
           tar -xzf apache-maven-3.5.4-bin.tar.gz
           export PATH=$PWD/apache-maven-3.5.4/bin:$PATH
@@ -24,7 +21,7 @@
           pip install mock
           pip3 install mock
           
-          mvn clean install -DskipTests
+          mvn clean install -DskipTests | tee $LOGS_PATH/build.txt
         chdir: '{{ zuul.project.src_dir }}'
         executable: /bin/bash
       environment: '{{ global_env }}'


### PR DESCRIPTION
This patch adds the CI configuration to enable the support for arm
build in OpenLab.

After this, each pull request in theopenlab/storm will trigger the
storm-arm64-build job which verified the arm build on ARM cluster.